### PR TITLE
Fix for keybindings firing while inside menus.

### DIFF
--- a/ForTheEmperor/scripts/mods/ForTheEmperor/ForTheEmperor.lua
+++ b/ForTheEmperor/scripts/mods/ForTheEmperor/ForTheEmperor.lua
@@ -1,6 +1,6 @@
 local mod = get_mod("ForTheEmperor")
 
---[[ 🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆 ]]
+--[[ ?????????????????????????????????? ]]
 
 Managers.package:load("packages/ui/views/social_menu_roster_view/social_menu_roster_view", "ForTheEmperor", nil, true)
 
@@ -57,9 +57,11 @@ end
 
 local comms_allowed = function()
 	local game_mode = Managers.state.game_mode and Managers.state.game_mode:game_mode_name()
+	local ui_manager = Managers.ui;
 	if
-		not (game_mode and Managers.player)
+		not (game_mode and Managers.player and ui_manager)
 		and (game_mode == "coop_complete_objective" or game_mode == "shooting_range" or game_mode == "prologue")
+		or (ui_manager.using_input())
 	then
 		return false
 	end

--- a/ForTheEmperor/scripts/mods/ForTheEmperor/ForTheEmperor.lua
+++ b/ForTheEmperor/scripts/mods/ForTheEmperor/ForTheEmperor.lua
@@ -61,7 +61,7 @@ local comms_allowed = function()
 	if
 		not (game_mode and Managers.player and ui_manager)
 		and (game_mode == "coop_complete_objective" or game_mode == "shooting_range" or game_mode == "prologue")
-		or (ui_manager.using_input())
+		or (ui_manager:using_input())
 	then
 		return false
 	end


### PR DESCRIPTION
Keybindings fire while inside menus. Add a check for whether the UI is using input, in which case we don't want to fire these keybindings. This includes chat, pause menu, inventory menu in the Psykhanium, etc.

The ducks got lost when opening the file locally. Leaving the re-adding up to you rather than linking two commits for you to look over.